### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #.idea/
 
 /data_dump/
+/tests/dumps

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ that your user has read and show constraints privileges for downloading data, an
 
 # Supported Neo4j Database Versions
 
-`Neo4j >= 4.x`
+`Neo4j >= 4.3`
 
 # Usage
 
@@ -119,19 +119,19 @@ This example shows saved data from a Node with complex data types.
         "bool_example": false,
         "born": 1956,
         "int_example": 1,
-        "point_3d_example": "point({x: 3.0, y: 0.0, z: 2.0, crs: 'cartesian-3d'})",
-        "localdatetime_example": "datetime('2015-07-04T19:32:24.000000000+00:00')",
-        "date_example": "date('1999-01-01')",
-        "point_2d_example": "point({x: 3.0, y: 0.0, crs: 'cartesian'})",
-        "datetime_example": "datetime('2015-06-24T12:50:35.556000000+01:00')",
-        "point_geo_3d_example": "point({x: 56.0, y: 12.0, z: 2, crs: 'wgs-84-3d'})",
-        "duration_example": "duration('P5M1DT12H')",
-        "odd_prop": "$time('21:40:32.142000000+01:00')",
+        "point_3d_example": "$point({x: 3.0, y: 0.0, z: 2.0, crs: 'cartesian-3d'})",
+        "localdatetime_example": "$datetime('2015-07-04T19:32:24.000000000+00:00')",
+        "date_example": "$date('1999-01-01')",
+        "point_2d_example": "$point({x: 3.0, y: 0.0, crs: 'cartesian'})",
+        "datetime_example": "$datetime('2015-06-24T12:50:35.556000000+01:00')",
+        "point_geo_3d_example": "$point({x: 56.0, y: 12.0, z: 2, crs: 'wgs-84-3d'})",
+        "duration_example": "$duration('P5M1DT12H')",
+        "odd_prop": "time('21:40:32.142000000+01:00')",
         "name": "Tom Hanks",
-        "localtime_example": "time('12:50:35.556000000+00:00')",
-        "point_geo_2d_example": "point({x: 56.0, y: 12.0, crs: 'wgs-84'})",
+        "localtime_example": "$time('12:50:35.556000000+00:00')",
+        "point_geo_2d_example": "$point({x: 56.0, y: 12.0, crs: 'wgs-84'})",
         "float_example": 0.334,
-        "time_example": "time('21:40:32.142000000+01:00')",
+        "time_example": "$time('21:40:32.142000000+01:00')",
         "array_example": [
             true,
             false
@@ -140,7 +140,7 @@ This example shows saved data from a Node with complex data types.
 }
 ```
 Note that the `odd_prop` was originally stored as a string in the database.
-The `$` denotes that the string is a literal string.
+The `$` denotes that the string is a string that need further processing.
 Relationships are stored in a very similar fashion.
 Example showing a Relationship with complex property values.
 
@@ -157,19 +157,19 @@ Example showing a Relationship with complex property values.
         ],
         "born": 1956,
         "int_example": 1,
-        "point_3d_example": "point({x: 3.0, y: 0.0, z: 2.0, crs: 'cartesian-3d'})",
-        "localdatetime_example": "datetime('2015-07-04T19:32:24.000000000+00:00')",
-        "date_example": "date('1999-01-01')",
-        "point_2d_example": "point({x: 3.0, y: 0.0, crs: 'cartesian'})",
-        "datetime_example": "datetime('2015-06-24T12:50:35.556000000+01:00')",
-        "point_geo_3d_example": "point({x: 56.0, y: 12.0, z: 2, crs: 'wgs-84-3d'})",
-        "duration_example": "duration('P5M1DT12H')",
-        "odd_prop": "$time('21:40:32.142000000+01:00')",
+        "point_3d_example": "$point({x: 3.0, y: 0.0, z: 2.0, crs: 'cartesian-3d'})",
+        "localdatetime_example": "$datetime('2015-07-04T19:32:24.000000000+00:00')",
+        "date_example": "$date('1999-01-01')",
+        "point_2d_example": "$point({x: 3.0, y: 0.0, crs: 'cartesian'})",
+        "datetime_example": "$datetime('2015-06-24T12:50:35.556000000+01:00')",
+        "point_geo_3d_example": "$point({x: 56.0, y: 12.0, z: 2, crs: 'wgs-84-3d'})",
+        "duration_example": "$duration('P5M1DT12H')",
+        "odd_prop": "time('21:40:32.142000000+01:00')",
         "name": "Tom Hanks",
-        "localtime_example": "time('12:50:35.556000000+00:00')",
-        "point_geo_2d_example": "point({x: 56.0, y: 12.0, crs: 'wgs-84'})",
+        "localtime_example": "$time('12:50:35.556000000+00:00')",
+        "point_geo_2d_example": "$point({x: 56.0, y: 12.0, crs: 'wgs-84'})",
         "float_example": 0.334,
-        "time_example": "time('21:40:32.142000000+01:00')",
+        "time_example": "$time('21:40:32.142000000+01:00')",
         "array_example": [
             true,
             false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neo4j_backup"
-version = "0.3.0"
+version = "0.3.1"
 description = "A simple way to backup and restore Neo4j databases without using dump files."
 readme = "README.md"
 authors = [{ name = "Andres Hyer", email = "andreshyer@gmail.com" }]
@@ -19,8 +19,7 @@ classifiers = [
 keywords = ["neo4j"]
 dependencies = [
     "neo4j>=4.3.0",
-    "tqdm>=4.10.0",
-    "orjson>=2.0.0"
+    "tqdm>=4.10.0"
 ]
 requires-python = ">=3.6"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 keywords = ["neo4j"]
 dependencies = [
-    "neo4j>=4.3.0",
+    "neo4j>=4.3.1",
     "tqdm>=4.10.0"
 ]
 requires-python = ">=3.6"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,26 @@
+# Unittests
+
+These scripts will become full unittest that are intergrated into Github.
+For now, test.py acts as a means of making sure that current code is working.
+
+## Installation (Linux)
+
+Docker must be installed, https://docs.docker.com/engine/install/ubuntu/.
+Afterwards, the user must be added to usergroup.
+Otherwise, you must run `test.py` as sudo.
+
+```
+sudo groupadd docker
+sudo usermod -aG docker $USER
+newgrp docker
+groups
+```
+
+Where $USER should be replaced with your actual username.
+If docker has been installed correctly, your username should be listed.
+
+## Usage
+
+Afterward, all that should be left is to run `test.py`.
+If `test.py` runs correctly, than the code is currently working.
+Otherwise, this script can help act as a guide as to what is breaking.

--- a/tests/queries/id_as_prop.cypher
+++ b/tests/queries/id_as_prop.cypher
@@ -1,0 +1,9 @@
+MATCH p=(sn)-[r]->(en)
+SET sn.node_id = ID(sn)
+SET en.node_id = ID(en)
+SET r.rel_id = ID(r)
+
+WITH COUNT(p) as p
+MATCH (n)
+WHERE NOT (n)-[]-()
+SET n.node_id = ID(n)

--- a/tests/queries/lonely_node.cypher
+++ b/tests/queries/lonely_node.cypher
@@ -1,0 +1,1 @@
+CREATE (p:Person:XX {name: "Joe Doe"})

--- a/tests/queries/modify_node.cypher
+++ b/tests/queries/modify_node.cypher
@@ -1,0 +1,20 @@
+MATCH (p:Person)
+WHERE p.name = "Tom Hanks"
+
+SET p.bool_example = false
+SET p.born = 1956
+SET p.int_example = 1
+SET p.point_3d_example = point({x: 3.0, y: 0.0, z: 2.0, crs: 'cartesian-3d'})
+SET p.localdatetime_example = datetime('2015-07-04T19:32:24.000000000+00:00')
+SET p.date_example = date('1999-01-01')
+SET p.point_2d_example = point({x: 3.0, y: 0.0, crs: 'cartesian'})
+SET p.datetime_example = datetime('2015-06-24T12:50:35.556000000+01:00')
+SET p.point_geo_3d_example = point({x: 56.0, y: 12.0, z: 2, crs: 'wgs-84-3d'})
+SET p.duration_example = duration('P5M1DT12H')
+SET p.odd_prop = "$time('21:40:32.142000000+01:00')"
+SET p.name = "Tom Hanks"
+SET p.localtime_example = time('12:50:35.556000000+00:00')
+SET p.point_geo_2d_example = point({x: 56.0, y: 12.0, crs: 'wgs-84'})
+SET p.float_example = 0.334
+SET p.time_example = time('21:40:32.142000000+01:00')
+SET p.array_example = [true, false]

--- a/tests/queries/modify_rel.cypher
+++ b/tests/queries/modify_rel.cypher
@@ -1,0 +1,22 @@
+MATCH (j:Person)
+WHERE j.name = "Tom Hanks"
+MATCH (j)-[p:ACTED_IN]-(m:Movie)
+WHERE m.title = "Cast Away"
+
+SET p.bool_example = false
+SET p.born = 1956
+SET p.int_example = 1
+SET p.point_3d_example = point({x: 3.0, y: 0.0, z: 2.0, crs: 'cartesian-3d'})
+SET p.localdatetime_example = datetime('2015-07-04T19:32:24.000000000+00:00')
+SET p.date_example = date('1999-01-01')
+SET p.point_2d_example = point({x: 3.0, y: 0.0, crs: 'cartesian'})
+SET p.datetime_example = datetime('2015-06-24T12:50:35.556000000+01:00')
+SET p.point_geo_3d_example = point({x: 56.0, y: 12.0, z: 2, crs: 'wgs-84-3d'})
+SET p.duration_example = duration('P5M1DT12H')
+SET p.odd_prop = "$time('21:40:32.142000000+01:00')"
+SET p.name = "Tom Hanks"
+SET p.localtime_example = time('12:50:35.556000000+00:00')
+SET p.point_geo_2d_example = point({x: 56.0, y: 12.0, crs: 'wgs-84'})
+SET p.float_example = 0.334
+SET p.time_example = time('21:40:32.142000000+01:00')
+SET p.array_example = [true, false]

--- a/tests/queries/movies.cypher
+++ b/tests/queries/movies.cypher
@@ -1,0 +1,505 @@
+CREATE (TheMatrix:Movie {title:'The Matrix', released:1999, tagline:'Welcome to the Real World'})
+CREATE (Keanu:Person {name:'Keanu Reeves', born:1964})
+CREATE (Carrie:Person {name:'Carrie-Anne Moss', born:1967})
+CREATE (Laurence:Person {name:'Laurence Fishburne', born:1961})
+CREATE (Hugo:Person {name:'Hugo Weaving', born:1960})
+CREATE (LillyW:Person {name:'Lilly Wachowski', born:1967})
+CREATE (LanaW:Person {name:'Lana Wachowski', born:1965})
+CREATE (JoelS:Person {name:'Joel Silver', born:1952})
+CREATE
+(Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrix),
+(Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrix),
+(Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrix),
+(Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrix),
+(LillyW)-[:DIRECTED]->(TheMatrix),
+(LanaW)-[:DIRECTED]->(TheMatrix),
+(JoelS)-[:PRODUCED]->(TheMatrix)
+
+CREATE (Emil:Person {name:"Emil Eifrem", born:1978})
+CREATE (Emil)-[:ACTED_IN {roles:["Emil"]}]->(TheMatrix)
+
+CREATE (TheMatrixReloaded:Movie {title:'The Matrix Reloaded', released:2003, tagline:'Free your mind'})
+CREATE
+(Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrixReloaded),
+(Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrixReloaded),
+(Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrixReloaded),
+(Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrixReloaded),
+(LillyW)-[:DIRECTED]->(TheMatrixReloaded),
+(LanaW)-[:DIRECTED]->(TheMatrixReloaded),
+(JoelS)-[:PRODUCED]->(TheMatrixReloaded)
+
+CREATE (TheMatrixRevolutions:Movie {title:'The Matrix Revolutions', released:2003, tagline:'Everything that has a beginning has an end'})
+CREATE
+(Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrixRevolutions),
+(Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrixRevolutions),
+(Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrixRevolutions),
+(Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrixRevolutions),
+(LillyW)-[:DIRECTED]->(TheMatrixRevolutions),
+(LanaW)-[:DIRECTED]->(TheMatrixRevolutions),
+(JoelS)-[:PRODUCED]->(TheMatrixRevolutions)
+
+CREATE (TheDevilsAdvocate:Movie {title:"The Devil's Advocate", released:1997, tagline:'Evil has its winning ways'})
+CREATE (Charlize:Person {name:'Charlize Theron', born:1975})
+CREATE (Al:Person {name:'Al Pacino', born:1940})
+CREATE (Taylor:Person {name:'Taylor Hackford', born:1944})
+CREATE
+(Keanu)-[:ACTED_IN {roles:['Kevin Lomax']}]->(TheDevilsAdvocate),
+(Charlize)-[:ACTED_IN {roles:['Mary Ann Lomax']}]->(TheDevilsAdvocate),
+(Al)-[:ACTED_IN {roles:['John Milton']}]->(TheDevilsAdvocate),
+(Taylor)-[:DIRECTED]->(TheDevilsAdvocate)
+
+CREATE (AFewGoodMen:Movie {title:"A Few Good Men", released:1992, tagline:"In the heart of the nation's capital, in a courthouse of the U.S. government, one man will stop at nothing to keep his honor, and one will stop at nothing to find the truth."})
+CREATE (TomC:Person {name:'Tom Cruise', born:1962})
+CREATE (JackN:Person {name:'Jack Nicholson', born:1937})
+CREATE (DemiM:Person {name:'Demi Moore', born:1962})
+CREATE (KevinB:Person {name:'Kevin Bacon', born:1958})
+CREATE (KieferS:Person {name:'Kiefer Sutherland', born:1966})
+CREATE (NoahW:Person {name:'Noah Wyle', born:1971})
+CREATE (CubaG:Person {name:'Cuba Gooding Jr.', born:1968})
+CREATE (KevinP:Person {name:'Kevin Pollak', born:1957})
+CREATE (JTW:Person {name:'J.T. Walsh', born:1943})
+CREATE (JamesM:Person {name:'James Marshall', born:1967})
+CREATE (ChristopherG:Person {name:'Christopher Guest', born:1948})
+CREATE (RobR:Person {name:'Rob Reiner', born:1947})
+CREATE (AaronS:Person {name:'Aaron Sorkin', born:1961})
+CREATE
+(TomC)-[:ACTED_IN {roles:['Lt. Daniel Kaffee']}]->(AFewGoodMen),
+(JackN)-[:ACTED_IN {roles:['Col. Nathan R. Jessup']}]->(AFewGoodMen),
+(DemiM)-[:ACTED_IN {roles:['Lt. Cdr. JoAnne Galloway']}]->(AFewGoodMen),
+(KevinB)-[:ACTED_IN {roles:['Capt. Jack Ross']}]->(AFewGoodMen),
+(KieferS)-[:ACTED_IN {roles:['Lt. Jonathan Kendrick']}]->(AFewGoodMen),
+(NoahW)-[:ACTED_IN {roles:['Cpl. Jeffrey Barnes']}]->(AFewGoodMen),
+(CubaG)-[:ACTED_IN {roles:['Cpl. Carl Hammaker']}]->(AFewGoodMen),
+(KevinP)-[:ACTED_IN {roles:['Lt. Sam Weinberg']}]->(AFewGoodMen),
+(JTW)-[:ACTED_IN {roles:['Lt. Col. Matthew Andrew Markinson']}]->(AFewGoodMen),
+(JamesM)-[:ACTED_IN {roles:['Pfc. Louden Downey']}]->(AFewGoodMen),
+(ChristopherG)-[:ACTED_IN {roles:['Dr. Stone']}]->(AFewGoodMen),
+(AaronS)-[:ACTED_IN {roles:['Man in Bar']}]->(AFewGoodMen),
+(RobR)-[:DIRECTED]->(AFewGoodMen),
+(AaronS)-[:WROTE]->(AFewGoodMen)
+
+CREATE (TopGun:Movie {title:"Top Gun", released:1986, tagline:'I feel the need, the need for speed.'})
+CREATE (KellyM:Person {name:'Kelly McGillis', born:1957})
+CREATE (ValK:Person {name:'Val Kilmer', born:1959})
+CREATE (AnthonyE:Person {name:'Anthony Edwards', born:1962})
+CREATE (TomS:Person {name:'Tom Skerritt', born:1933})
+CREATE (MegR:Person {name:'Meg Ryan', born:1961})
+CREATE (TonyS:Person {name:'Tony Scott', born:1944})
+CREATE (JimC:Person {name:'Jim Cash', born:1941})
+CREATE
+(TomC)-[:ACTED_IN {roles:['Maverick']}]->(TopGun),
+(KellyM)-[:ACTED_IN {roles:['Charlie']}]->(TopGun),
+(ValK)-[:ACTED_IN {roles:['Iceman']}]->(TopGun),
+(AnthonyE)-[:ACTED_IN {roles:['Goose']}]->(TopGun),
+(TomS)-[:ACTED_IN {roles:['Viper']}]->(TopGun),
+(MegR)-[:ACTED_IN {roles:['Carole']}]->(TopGun),
+(TonyS)-[:DIRECTED]->(TopGun),
+(JimC)-[:WROTE]->(TopGun)
+
+CREATE (JerryMaguire:Movie {title:'Jerry Maguire', released:2000, tagline:'The rest of his life begins now.'})
+CREATE (ReneeZ:Person {name:'Renee Zellweger', born:1969})
+CREATE (KellyP:Person {name:'Kelly Preston', born:1962})
+CREATE (JerryO:Person {name:"Jerry O'Connell", born:1974})
+CREATE (JayM:Person {name:'Jay Mohr', born:1970})
+CREATE (BonnieH:Person {name:'Bonnie Hunt', born:1961})
+CREATE (ReginaK:Person {name:'Regina King', born:1971})
+CREATE (JonathanL:Person {name:'Jonathan Lipnicki', born:1996})
+CREATE (CameronC:Person {name:'Cameron Crowe', born:1957})
+CREATE
+(TomC)-[:ACTED_IN {roles:['Jerry Maguire']}]->(JerryMaguire),
+(CubaG)-[:ACTED_IN {roles:['Rod Tidwell']}]->(JerryMaguire),
+(ReneeZ)-[:ACTED_IN {roles:['Dorothy Boyd']}]->(JerryMaguire),
+(KellyP)-[:ACTED_IN {roles:['Avery Bishop']}]->(JerryMaguire),
+(JerryO)-[:ACTED_IN {roles:['Frank Cushman']}]->(JerryMaguire),
+(JayM)-[:ACTED_IN {roles:['Bob Sugar']}]->(JerryMaguire),
+(BonnieH)-[:ACTED_IN {roles:['Laurel Boyd']}]->(JerryMaguire),
+(ReginaK)-[:ACTED_IN {roles:['Marcee Tidwell']}]->(JerryMaguire),
+(JonathanL)-[:ACTED_IN {roles:['Ray Boyd']}]->(JerryMaguire),
+(CameronC)-[:DIRECTED]->(JerryMaguire),
+(CameronC)-[:PRODUCED]->(JerryMaguire),
+(CameronC)-[:WROTE]->(JerryMaguire)
+
+CREATE (StandByMe:Movie {title:"Stand By Me", released:1986, tagline:"For some, it's the last real taste of innocence, and the first real taste of life. But for everyone, it's the time that memories are made of."})
+CREATE (RiverP:Person {name:'River Phoenix', born:1970})
+CREATE (CoreyF:Person {name:'Corey Feldman', born:1971})
+CREATE (WilW:Person {name:'Wil Wheaton', born:1972})
+CREATE (JohnC:Person {name:'John Cusack', born:1966})
+CREATE (MarshallB:Person {name:'Marshall Bell', born:1942})
+CREATE
+(WilW)-[:ACTED_IN {roles:['Gordie Lachance']}]->(StandByMe),
+(RiverP)-[:ACTED_IN {roles:['Chris Chambers']}]->(StandByMe),
+(JerryO)-[:ACTED_IN {roles:['Vern Tessio']}]->(StandByMe),
+(CoreyF)-[:ACTED_IN {roles:['Teddy Duchamp']}]->(StandByMe),
+(JohnC)-[:ACTED_IN {roles:['Denny Lachance']}]->(StandByMe),
+(KieferS)-[:ACTED_IN {roles:['Ace Merrill']}]->(StandByMe),
+(MarshallB)-[:ACTED_IN {roles:['Mr. Lachance']}]->(StandByMe),
+(RobR)-[:DIRECTED]->(StandByMe)
+
+CREATE (AsGoodAsItGets:Movie {title:'As Good as It Gets', released:1997, tagline:'A comedy from the heart that goes for the throat.'})
+CREATE (HelenH:Person {name:'Helen Hunt', born:1963})
+CREATE (GregK:Person {name:'Greg Kinnear', born:1963})
+CREATE (JamesB:Person {name:'James L. Brooks', born:1940})
+CREATE
+(JackN)-[:ACTED_IN {roles:['Melvin Udall']}]->(AsGoodAsItGets),
+(HelenH)-[:ACTED_IN {roles:['Carol Connelly']}]->(AsGoodAsItGets),
+(GregK)-[:ACTED_IN {roles:['Simon Bishop']}]->(AsGoodAsItGets),
+(CubaG)-[:ACTED_IN {roles:['Frank Sachs']}]->(AsGoodAsItGets),
+(JamesB)-[:DIRECTED]->(AsGoodAsItGets)
+
+CREATE (WhatDreamsMayCome:Movie {title:'What Dreams May Come', released:1998, tagline:'After life there is more. The end is just the beginning.'})
+CREATE (AnnabellaS:Person {name:'Annabella Sciorra', born:1960})
+CREATE (MaxS:Person {name:'Max von Sydow', born:1929})
+CREATE (WernerH:Person {name:'Werner Herzog', born:1942})
+CREATE (Robin:Person {name:'Robin Williams', born:1951})
+CREATE (VincentW:Person {name:'Vincent Ward', born:1956})
+CREATE
+(Robin)-[:ACTED_IN {roles:['Chris Nielsen']}]->(WhatDreamsMayCome),
+(CubaG)-[:ACTED_IN {roles:['Albert Lewis']}]->(WhatDreamsMayCome),
+(AnnabellaS)-[:ACTED_IN {roles:['Annie Collins-Nielsen']}]->(WhatDreamsMayCome),
+(MaxS)-[:ACTED_IN {roles:['The Tracker']}]->(WhatDreamsMayCome),
+(WernerH)-[:ACTED_IN {roles:['The Face']}]->(WhatDreamsMayCome),
+(VincentW)-[:DIRECTED]->(WhatDreamsMayCome)
+
+CREATE (SnowFallingonCedars:Movie {title:'Snow Falling on Cedars', released:1999, tagline:'First loves last. Forever.'})
+CREATE (EthanH:Person {name:'Ethan Hawke', born:1970})
+CREATE (RickY:Person {name:'Rick Yune', born:1971})
+CREATE (JamesC:Person {name:'James Cromwell', born:1940})
+CREATE (ScottH:Person {name:'Scott Hicks', born:1953})
+CREATE
+(EthanH)-[:ACTED_IN {roles:['Ishmael Chambers']}]->(SnowFallingonCedars),
+(RickY)-[:ACTED_IN {roles:['Kazuo Miyamoto']}]->(SnowFallingonCedars),
+(MaxS)-[:ACTED_IN {roles:['Nels Gudmundsson']}]->(SnowFallingonCedars),
+(JamesC)-[:ACTED_IN {roles:['Judge Fielding']}]->(SnowFallingonCedars),
+(ScottH)-[:DIRECTED]->(SnowFallingonCedars)
+
+CREATE (YouveGotMail:Movie {title:"You've Got Mail", released:1998, tagline:'At odds in life... in love on-line.'})
+CREATE (ParkerP:Person {name:'Parker Posey', born:1968})
+CREATE (DaveC:Person {name:'Dave Chappelle', born:1973})
+CREATE (SteveZ:Person {name:'Steve Zahn', born:1967})
+CREATE (TomH:Person {name:'Tom Hanks', born:1956})
+CREATE (NoraE:Person {name:'Nora Ephron', born:1941})
+CREATE
+(TomH)-[:ACTED_IN {roles:['Joe Fox']}]->(YouveGotMail),
+(MegR)-[:ACTED_IN {roles:['Kathleen Kelly']}]->(YouveGotMail),
+(GregK)-[:ACTED_IN {roles:['Frank Navasky']}]->(YouveGotMail),
+(ParkerP)-[:ACTED_IN {roles:['Patricia Eden']}]->(YouveGotMail),
+(DaveC)-[:ACTED_IN {roles:['Kevin Jackson']}]->(YouveGotMail),
+(SteveZ)-[:ACTED_IN {roles:['George Pappas']}]->(YouveGotMail),
+(NoraE)-[:DIRECTED]->(YouveGotMail)
+
+CREATE (SleeplessInSeattle:Movie {title:'Sleepless in Seattle', released:1993, tagline:'What if someone you never met, someone you never saw, someone you never knew was the only someone for you?'})
+CREATE (RitaW:Person {name:'Rita Wilson', born:1956})
+CREATE (BillPull:Person {name:'Bill Pullman', born:1953})
+CREATE (VictorG:Person {name:'Victor Garber', born:1949})
+CREATE (RosieO:Person {name:"Rosie O'Donnell", born:1962})
+CREATE
+(TomH)-[:ACTED_IN {roles:['Sam Baldwin']}]->(SleeplessInSeattle),
+(MegR)-[:ACTED_IN {roles:['Annie Reed']}]->(SleeplessInSeattle),
+(RitaW)-[:ACTED_IN {roles:['Suzy']}]->(SleeplessInSeattle),
+(BillPull)-[:ACTED_IN {roles:['Walter']}]->(SleeplessInSeattle),
+(VictorG)-[:ACTED_IN {roles:['Greg']}]->(SleeplessInSeattle),
+(RosieO)-[:ACTED_IN {roles:['Becky']}]->(SleeplessInSeattle),
+(NoraE)-[:DIRECTED]->(SleeplessInSeattle)
+
+CREATE (JoeVersustheVolcano:Movie {title:'Joe Versus the Volcano', released:1990, tagline:'A story of love, lava and burning desire.'})
+CREATE (JohnS:Person {name:'John Patrick Stanley', born:1950})
+CREATE (Nathan:Person {name:'Nathan Lane', born:1956})
+CREATE
+(TomH)-[:ACTED_IN {roles:['Joe Banks']}]->(JoeVersustheVolcano),
+(MegR)-[:ACTED_IN {roles:['DeDe', 'Angelica Graynamore', 'Patricia Graynamore']}]->(JoeVersustheVolcano),
+(Nathan)-[:ACTED_IN {roles:['Baw']}]->(JoeVersustheVolcano),
+(JohnS)-[:DIRECTED]->(JoeVersustheVolcano)
+
+CREATE (WhenHarryMetSally:Movie {title:'When Harry Met Sally', released:1998, tagline:'Can two friends sleep together and still love each other in the morning?'})
+CREATE (BillyC:Person {name:'Billy Crystal', born:1948})
+CREATE (CarrieF:Person {name:'Carrie Fisher', born:1956})
+CREATE (BrunoK:Person {name:'Bruno Kirby', born:1949})
+CREATE
+(BillyC)-[:ACTED_IN {roles:['Harry Burns']}]->(WhenHarryMetSally),
+(MegR)-[:ACTED_IN {roles:['Sally Albright']}]->(WhenHarryMetSally),
+(CarrieF)-[:ACTED_IN {roles:['Marie']}]->(WhenHarryMetSally),
+(BrunoK)-[:ACTED_IN {roles:['Jess']}]->(WhenHarryMetSally),
+(RobR)-[:DIRECTED]->(WhenHarryMetSally),
+(RobR)-[:PRODUCED]->(WhenHarryMetSally),
+(NoraE)-[:PRODUCED]->(WhenHarryMetSally),
+(NoraE)-[:WROTE]->(WhenHarryMetSally)
+
+CREATE (ThatThingYouDo:Movie {title:'That Thing You Do', released:1996, tagline:'In every life there comes a time when that thing you dream becomes that thing you do'})
+CREATE (LivT:Person {name:'Liv Tyler', born:1977})
+CREATE
+(TomH)-[:ACTED_IN {roles:['Mr. White']}]->(ThatThingYouDo),
+(LivT)-[:ACTED_IN {roles:['Faye Dolan']}]->(ThatThingYouDo),
+(Charlize)-[:ACTED_IN {roles:['Tina']}]->(ThatThingYouDo),
+(TomH)-[:DIRECTED]->(ThatThingYouDo)
+
+CREATE (TheReplacements:Movie {title:'The Replacements', released:2000, tagline:'Pain heals, Chicks dig scars... Glory lasts forever'})
+CREATE (Brooke:Person {name:'Brooke Langton', born:1970})
+CREATE (Gene:Person {name:'Gene Hackman', born:1930})
+CREATE (Orlando:Person {name:'Orlando Jones', born:1968})
+CREATE (Howard:Person {name:'Howard Deutch', born:1950})
+CREATE
+(Keanu)-[:ACTED_IN {roles:['Shane Falco']}]->(TheReplacements),
+(Brooke)-[:ACTED_IN {roles:['Annabelle Farrell']}]->(TheReplacements),
+(Gene)-[:ACTED_IN {roles:['Jimmy McGinty']}]->(TheReplacements),
+(Orlando)-[:ACTED_IN {roles:['Clifford Franklin']}]->(TheReplacements),
+(Howard)-[:DIRECTED]->(TheReplacements)
+
+CREATE (RescueDawn:Movie {title:'RescueDawn', released:2006, tagline:"Based on the extraordinary true story of one man's fight for freedom"})
+CREATE (ChristianB:Person {name:'Christian Bale', born:1974})
+CREATE (ZachG:Person {name:'Zach Grenier', born:1954})
+CREATE
+(MarshallB)-[:ACTED_IN {roles:['Admiral']}]->(RescueDawn),
+(ChristianB)-[:ACTED_IN {roles:['Dieter Dengler']}]->(RescueDawn),
+(ZachG)-[:ACTED_IN {roles:['Squad Leader']}]->(RescueDawn),
+(SteveZ)-[:ACTED_IN {roles:['Duane']}]->(RescueDawn),
+(WernerH)-[:DIRECTED]->(RescueDawn)
+
+CREATE (TheBirdcage:Movie {title:'The Birdcage', released:1996, tagline:'Come as you are'})
+CREATE (MikeN:Person {name:'Mike Nichols', born:1931})
+CREATE
+(Robin)-[:ACTED_IN {roles:['Armand Goldman']}]->(TheBirdcage),
+(Nathan)-[:ACTED_IN {roles:['Albert Goldman']}]->(TheBirdcage),
+(Gene)-[:ACTED_IN {roles:['Sen. Kevin Keeley']}]->(TheBirdcage),
+(MikeN)-[:DIRECTED]->(TheBirdcage)
+
+CREATE (Unforgiven:Movie {title:'Unforgiven', released:1992, tagline:"It's a hell of a thing, killing a man"})
+CREATE (RichardH:Person {name:'Richard Harris', born:1930})
+CREATE (ClintE:Person {name:'Clint Eastwood', born:1930})
+CREATE
+(RichardH)-[:ACTED_IN {roles:['English Bob']}]->(Unforgiven),
+(ClintE)-[:ACTED_IN {roles:['Bill Munny']}]->(Unforgiven),
+(Gene)-[:ACTED_IN {roles:['Little Bill Daggett']}]->(Unforgiven),
+(ClintE)-[:DIRECTED]->(Unforgiven)
+
+CREATE (JohnnyMnemonic:Movie {title:'Johnny Mnemonic', released:1995, tagline:'The hottest data on earth. In the coolest head in town'})
+CREATE (Takeshi:Person {name:'Takeshi Kitano', born:1947})
+CREATE (Dina:Person {name:'Dina Meyer', born:1968})
+CREATE (IceT:Person {name:'Ice-T', born:1958})
+CREATE (RobertL:Person {name:'Robert Longo', born:1953})
+CREATE
+(Keanu)-[:ACTED_IN {roles:['Johnny Mnemonic']}]->(JohnnyMnemonic),
+(Takeshi)-[:ACTED_IN {roles:['Takahashi']}]->(JohnnyMnemonic),
+(Dina)-[:ACTED_IN {roles:['Jane']}]->(JohnnyMnemonic),
+(IceT)-[:ACTED_IN {roles:['J-Bone']}]->(JohnnyMnemonic),
+(RobertL)-[:DIRECTED]->(JohnnyMnemonic)
+
+CREATE (CloudAtlas:Movie {title:'Cloud Atlas', released:2012, tagline:'Everything is connected'})
+CREATE (HalleB:Person {name:'Halle Berry', born:1966})
+CREATE (JimB:Person {name:'Jim Broadbent', born:1949})
+CREATE (TomT:Person {name:'Tom Tykwer', born:1965})
+CREATE (DavidMitchell:Person {name:'David Mitchell', born:1969})
+CREATE (StefanArndt:Person {name:'Stefan Arndt', born:1961})
+CREATE
+(TomH)-[:ACTED_IN {roles:['Zachry', 'Dr. Henry Goose', 'Isaac Sachs', 'Dermot Hoggins']}]->(CloudAtlas),
+(Hugo)-[:ACTED_IN {roles:['Bill Smoke', 'Haskell Moore', 'Tadeusz Kesselring', 'Nurse Noakes', 'Boardman Mephi', 'Old Georgie']}]->(CloudAtlas),
+(HalleB)-[:ACTED_IN {roles:['Luisa Rey', 'Jocasta Ayrs', 'Ovid', 'Meronym']}]->(CloudAtlas),
+(JimB)-[:ACTED_IN {roles:['Vyvyan Ayrs', 'Captain Molyneux', 'Timothy Cavendish']}]->(CloudAtlas),
+(TomT)-[:DIRECTED]->(CloudAtlas),
+(LillyW)-[:DIRECTED]->(CloudAtlas),
+(LanaW)-[:DIRECTED]->(CloudAtlas),
+(DavidMitchell)-[:WROTE]->(CloudAtlas),
+(StefanArndt)-[:PRODUCED]->(CloudAtlas)
+
+CREATE (TheDaVinciCode:Movie {title:'The Da Vinci Code', released:2006, tagline:'Break The Codes'})
+CREATE (IanM:Person {name:'Ian McKellen', born:1939})
+CREATE (AudreyT:Person {name:'Audrey Tautou', born:1976})
+CREATE (PaulB:Person {name:'Paul Bettany', born:1971})
+CREATE (RonH:Person {name:'Ron Howard', born:1954})
+CREATE
+(TomH)-[:ACTED_IN {roles:['Dr. Robert Langdon']}]->(TheDaVinciCode),
+(IanM)-[:ACTED_IN {roles:['Sir Leight Teabing']}]->(TheDaVinciCode),
+(AudreyT)-[:ACTED_IN {roles:['Sophie Neveu']}]->(TheDaVinciCode),
+(PaulB)-[:ACTED_IN {roles:['Silas']}]->(TheDaVinciCode),
+(RonH)-[:DIRECTED]->(TheDaVinciCode)
+
+CREATE (VforVendetta:Movie {title:'V for Vendetta', released:2006, tagline:'Freedom! Forever!'})
+CREATE (NatalieP:Person {name:'Natalie Portman', born:1981})
+CREATE (StephenR:Person {name:'Stephen Rea', born:1946})
+CREATE (JohnH:Person {name:'John Hurt', born:1940})
+CREATE (BenM:Person {name: 'Ben Miles', born:1967})
+CREATE
+(Hugo)-[:ACTED_IN {roles:['V']}]->(VforVendetta),
+(NatalieP)-[:ACTED_IN {roles:['Evey Hammond']}]->(VforVendetta),
+(StephenR)-[:ACTED_IN {roles:['Eric Finch']}]->(VforVendetta),
+(JohnH)-[:ACTED_IN {roles:['High Chancellor Adam Sutler']}]->(VforVendetta),
+(BenM)-[:ACTED_IN {roles:['Dascomb']}]->(VforVendetta),
+(JamesM)-[:DIRECTED]->(VforVendetta),
+(LillyW)-[:PRODUCED]->(VforVendetta),
+(LanaW)-[:PRODUCED]->(VforVendetta),
+(JoelS)-[:PRODUCED]->(VforVendetta),
+(LillyW)-[:WROTE]->(VforVendetta),
+(LanaW)-[:WROTE]->(VforVendetta)
+
+CREATE (SpeedRacer:Movie {title:'Speed Racer', released:2008, tagline:'Speed has no limits'})
+CREATE (EmileH:Person {name:'Emile Hirsch', born:1985})
+CREATE (JohnG:Person {name:'John Goodman', born:1960})
+CREATE (SusanS:Person {name:'Susan Sarandon', born:1946})
+CREATE (MatthewF:Person {name:'Matthew Fox', born:1966})
+CREATE (ChristinaR:Person {name:'Christina Ricci', born:1980})
+CREATE (Rain:Person {name:'Rain', born:1982})
+CREATE
+(EmileH)-[:ACTED_IN {roles:['Speed Racer']}]->(SpeedRacer),
+(JohnG)-[:ACTED_IN {roles:['Pops']}]->(SpeedRacer),
+(SusanS)-[:ACTED_IN {roles:['Mom']}]->(SpeedRacer),
+(MatthewF)-[:ACTED_IN {roles:['Racer X']}]->(SpeedRacer),
+(ChristinaR)-[:ACTED_IN {roles:['Trixie']}]->(SpeedRacer),
+(Rain)-[:ACTED_IN {roles:['Taejo Togokahn']}]->(SpeedRacer),
+(BenM)-[:ACTED_IN {roles:['Cass Jones']}]->(SpeedRacer),
+(LillyW)-[:DIRECTED]->(SpeedRacer),
+(LanaW)-[:DIRECTED]->(SpeedRacer),
+(LillyW)-[:WROTE]->(SpeedRacer),
+(LanaW)-[:WROTE]->(SpeedRacer),
+(JoelS)-[:PRODUCED]->(SpeedRacer)
+
+CREATE (NinjaAssassin:Movie {title:'Ninja Assassin', released:2009, tagline:'Prepare to enter a secret world of assassins'})
+CREATE (NaomieH:Person {name:'Naomie Harris'})
+CREATE
+(Rain)-[:ACTED_IN {roles:['Raizo']}]->(NinjaAssassin),
+(NaomieH)-[:ACTED_IN {roles:['Mika Coretti']}]->(NinjaAssassin),
+(RickY)-[:ACTED_IN {roles:['Takeshi']}]->(NinjaAssassin),
+(BenM)-[:ACTED_IN {roles:['Ryan Maslow']}]->(NinjaAssassin),
+(JamesM)-[:DIRECTED]->(NinjaAssassin),
+(LillyW)-[:PRODUCED]->(NinjaAssassin),
+(LanaW)-[:PRODUCED]->(NinjaAssassin),
+(JoelS)-[:PRODUCED]->(NinjaAssassin)
+
+CREATE (TheGreenMile:Movie {title:'The Green Mile', released:1999, tagline:"Walk a mile you'll never forget."})
+CREATE (MichaelD:Person {name:'Michael Clarke Duncan', born:1957})
+CREATE (DavidM:Person {name:'David Morse', born:1953})
+CREATE (SamR:Person {name:'Sam Rockwell', born:1968})
+CREATE (GaryS:Person {name:'Gary Sinise', born:1955})
+CREATE (PatriciaC:Person {name:'Patricia Clarkson', born:1959})
+CREATE (FrankD:Person {name:'Frank Darabont', born:1959})
+CREATE
+(TomH)-[:ACTED_IN {roles:['Paul Edgecomb']}]->(TheGreenMile),
+(MichaelD)-[:ACTED_IN {roles:['John Coffey']}]->(TheGreenMile),
+(DavidM)-[:ACTED_IN {roles:['Brutus "Brutal" Howell']}]->(TheGreenMile),
+(BonnieH)-[:ACTED_IN {roles:['Jan Edgecomb']}]->(TheGreenMile),
+(JamesC)-[:ACTED_IN {roles:['Warden Hal Moores']}]->(TheGreenMile),
+(SamR)-[:ACTED_IN {roles:['"Wild Bill" Wharton']}]->(TheGreenMile),
+(GaryS)-[:ACTED_IN {roles:['Burt Hammersmith']}]->(TheGreenMile),
+(PatriciaC)-[:ACTED_IN {roles:['Melinda Moores']}]->(TheGreenMile),
+(FrankD)-[:DIRECTED]->(TheGreenMile)
+
+CREATE (FrostNixon:Movie {title:'Frost/Nixon', released:2008, tagline:'400 million people were waiting for the truth.'})
+CREATE (FrankL:Person {name:'Frank Langella', born:1938})
+CREATE (MichaelS:Person {name:'Michael Sheen', born:1969})
+CREATE (OliverP:Person {name:'Oliver Platt', born:1960})
+CREATE
+(FrankL)-[:ACTED_IN {roles:['Richard Nixon']}]->(FrostNixon),
+(MichaelS)-[:ACTED_IN {roles:['David Frost']}]->(FrostNixon),
+(KevinB)-[:ACTED_IN {roles:['Jack Brennan']}]->(FrostNixon),
+(OliverP)-[:ACTED_IN {roles:['Bob Zelnick']}]->(FrostNixon),
+(SamR)-[:ACTED_IN {roles:['James Reston, Jr.']}]->(FrostNixon),
+(RonH)-[:DIRECTED]->(FrostNixon)
+
+CREATE (Hoffa:Movie {title:'Hoffa', released:1992, tagline:"He didn't want law. He wanted justice."})
+CREATE (DannyD:Person {name:'Danny DeVito', born:1944})
+CREATE (JohnR:Person {name:'John C. Reilly', born:1965})
+CREATE
+(JackN)-[:ACTED_IN {roles:['Hoffa']}]->(Hoffa),
+(DannyD)-[:ACTED_IN {roles:['Robert "Bobby" Ciaro']}]->(Hoffa),
+(JTW)-[:ACTED_IN {roles:['Frank Fitzsimmons']}]->(Hoffa),
+(JohnR)-[:ACTED_IN {roles:['Peter "Pete" Connelly']}]->(Hoffa),
+(DannyD)-[:DIRECTED]->(Hoffa)
+
+CREATE (Apollo13:Movie {title:'Apollo 13', released:1995, tagline:'Houston, we have a problem.'})
+CREATE (EdH:Person {name:'Ed Harris', born:1950})
+CREATE (BillPax:Person {name:'Bill Paxton', born:1955})
+CREATE
+(TomH)-[:ACTED_IN {roles:['Jim Lovell']}]->(Apollo13),
+(KevinB)-[:ACTED_IN {roles:['Jack Swigert']}]->(Apollo13),
+(EdH)-[:ACTED_IN {roles:['Gene Kranz']}]->(Apollo13),
+(BillPax)-[:ACTED_IN {roles:['Fred Haise']}]->(Apollo13),
+(GaryS)-[:ACTED_IN {roles:['Ken Mattingly']}]->(Apollo13),
+(RonH)-[:DIRECTED]->(Apollo13)
+
+CREATE (Twister:Movie {title:'Twister', released:1996, tagline:"Don't Breathe. Don't Look Back."})
+CREATE (PhilipH:Person {name:'Philip Seymour Hoffman', born:1967})
+CREATE (JanB:Person {name:'Jan de Bont', born:1943})
+CREATE
+(BillPax)-[:ACTED_IN {roles:['Bill Harding']}]->(Twister),
+(HelenH)-[:ACTED_IN {roles:['Dr. Jo Harding']}]->(Twister),
+(ZachG)-[:ACTED_IN {roles:['Eddie']}]->(Twister),
+(PhilipH)-[:ACTED_IN {roles:['Dustin "Dusty" Davis']}]->(Twister),
+(JanB)-[:DIRECTED]->(Twister)
+
+CREATE (CastAway:Movie {title:'Cast Away', released:2000, tagline:'At the edge of the world, his journey begins.'})
+CREATE (RobertZ:Person {name:'Robert Zemeckis', born:1951})
+CREATE
+(TomH)-[:ACTED_IN {roles:['Chuck Noland']}]->(CastAway),
+(HelenH)-[:ACTED_IN {roles:['Kelly Frears']}]->(CastAway),
+(RobertZ)-[:DIRECTED]->(CastAway)
+
+CREATE (OneFlewOvertheCuckoosNest:Movie {title:"One Flew Over the Cuckoo's Nest", released:1975, tagline:"If he's crazy, what does that make you?"})
+CREATE (MilosF:Person {name:'Milos Forman', born:1932})
+CREATE
+(JackN)-[:ACTED_IN {roles:['Randle McMurphy']}]->(OneFlewOvertheCuckoosNest),
+(DannyD)-[:ACTED_IN {roles:['Martini']}]->(OneFlewOvertheCuckoosNest),
+(MilosF)-[:DIRECTED]->(OneFlewOvertheCuckoosNest)
+
+CREATE (SomethingsGottaGive:Movie {title:"Something's Gotta Give", released:2003})
+CREATE (DianeK:Person {name:'Diane Keaton', born:1946})
+CREATE (NancyM:Person {name:'Nancy Meyers', born:1949})
+CREATE
+(JackN)-[:ACTED_IN {roles:['Harry Sanborn']}]->(SomethingsGottaGive),
+(DianeK)-[:ACTED_IN {roles:['Erica Barry']}]->(SomethingsGottaGive),
+(Keanu)-[:ACTED_IN {roles:['Julian Mercer']}]->(SomethingsGottaGive),
+(NancyM)-[:DIRECTED]->(SomethingsGottaGive),
+(NancyM)-[:PRODUCED]->(SomethingsGottaGive),
+(NancyM)-[:WROTE]->(SomethingsGottaGive)
+
+CREATE (BicentennialMan:Movie {title:'Bicentennial Man', released:1999, tagline:"One robot's 200 year journey to become an ordinary man."})
+CREATE (ChrisC:Person {name:'Chris Columbus', born:1958})
+CREATE
+(Robin)-[:ACTED_IN {roles:['Andrew Marin']}]->(BicentennialMan),
+(OliverP)-[:ACTED_IN {roles:['Rupert Burns']}]->(BicentennialMan),
+(ChrisC)-[:DIRECTED]->(BicentennialMan)
+
+CREATE (CharlieWilsonsWar:Movie {title:"Charlie Wilson's War", released:2007, tagline:"A stiff drink. A little mascara. A lot of nerve. Who said they couldn't bring down the Soviet empire."})
+CREATE (JuliaR:Person {name:'Julia Roberts', born:1967})
+CREATE
+(TomH)-[:ACTED_IN {roles:['Rep. Charlie Wilson']}]->(CharlieWilsonsWar),
+(JuliaR)-[:ACTED_IN {roles:['Joanne Herring']}]->(CharlieWilsonsWar),
+(PhilipH)-[:ACTED_IN {roles:['Gust Avrakotos']}]->(CharlieWilsonsWar),
+(MikeN)-[:DIRECTED]->(CharlieWilsonsWar)
+
+CREATE (ThePolarExpress:Movie {title:'The Polar Express', released:2004, tagline:'This Holiday Season... Believe'})
+CREATE
+(TomH)-[:ACTED_IN {roles:['Hero Boy', 'Father', 'Conductor', 'Hobo', 'Scrooge', 'Santa Claus']}]->(ThePolarExpress),
+(RobertZ)-[:DIRECTED]->(ThePolarExpress)
+
+CREATE (ALeagueofTheirOwn:Movie {title:'A League of Their Own', released:1992, tagline:'Once in a lifetime you get a chance to do something different.'})
+CREATE (Madonna:Person {name:'Madonna', born:1954})
+CREATE (GeenaD:Person {name:'Geena Davis', born:1956})
+CREATE (LoriP:Person {name:'Lori Petty', born:1963})
+CREATE (PennyM:Person {name:'Penny Marshall', born:1943})
+CREATE
+(TomH)-[:ACTED_IN {roles:['Jimmy Dugan']}]->(ALeagueofTheirOwn),
+(GeenaD)-[:ACTED_IN {roles:['Dottie Hinson']}]->(ALeagueofTheirOwn),
+(LoriP)-[:ACTED_IN {roles:['Kit Keller']}]->(ALeagueofTheirOwn),
+(RosieO)-[:ACTED_IN {roles:['Doris Murphy']}]->(ALeagueofTheirOwn),
+(Madonna)-[:ACTED_IN {roles:['"All the Way" Mae Mordabito']}]->(ALeagueofTheirOwn),
+(BillPax)-[:ACTED_IN {roles:['Bob Hinson']}]->(ALeagueofTheirOwn),
+(PennyM)-[:DIRECTED]->(ALeagueofTheirOwn)
+
+CREATE (PaulBlythe:Person {name:'Paul Blythe'})
+CREATE (AngelaScope:Person {name:'Angela Scope'})
+CREATE (JessicaThompson:Person {name:'Jessica Thompson'})
+CREATE (JamesThompson:Person {name:'James Thompson'})
+
+CREATE
+(JamesThompson)-[:FOLLOWS]->(JessicaThompson),
+(AngelaScope)-[:FOLLOWS]->(JessicaThompson),
+(PaulBlythe)-[:FOLLOWS]->(AngelaScope)
+
+CREATE
+(JessicaThompson)-[:REVIEWED {summary:'An amazing journey', rating:95}]->(CloudAtlas),
+(JessicaThompson)-[:REVIEWED {summary:'Silly, but fun', rating:65}]->(TheReplacements),
+(JamesThompson)-[:REVIEWED {summary:'The coolest football movie ever', rating:100}]->(TheReplacements),
+(AngelaScope)-[:REVIEWED {summary:'Pretty funny at times', rating:62}]->(TheReplacements),
+(JessicaThompson)-[:REVIEWED {summary:'Dark, but compelling', rating:85}]->(Unforgiven),
+(JessicaThompson)-[:REVIEWED {summary:"Slapstick redeemed only by the Robin Williams and Gene Hackman's stellar performances", rating:45}]->(TheBirdcage),
+(JessicaThompson)-[:REVIEWED {summary:'A solid romp', rating:68}]->(TheDaVinciCode),
+(JamesThompson)-[:REVIEWED {summary:'Fun, but a little far fetched', rating:65}]->(TheDaVinciCode),
+(JessicaThompson)-[:REVIEWED {summary:'You had me at Jerry', rating:92}]->(JerryMaguire)

--- a/tests/queries/v4_constraint.cypher
+++ b/tests/queries/v4_constraint.cypher
@@ -1,0 +1,3 @@
+CREATE CONSTRAINT
+ON (n:Person)
+ASSERT n.node_id IS UNIQUE

--- a/tests/queries/v5_constraint.cypher
+++ b/tests/queries/v5_constraint.cypher
@@ -1,0 +1,3 @@
+CREATE CONSTRAINT
+FOR (n:Person)
+REQUIRE n.node_id IS UNIQUE

--- a/tests/tags.json
+++ b/tests/tags.json
@@ -1,0 +1,1 @@
+["4.1.0-community", "4.2.0-community", "4.3.0-community", "4.4.0-community", "5-community", "5.1.0-community", "5.2.0-community", "5.3.0-community", "5.4.0-community", "5.5.0-community", "latest"]

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,267 @@
+from pathlib import Path
+from json import load
+from time import sleep
+from shutil import rmtree
+from os import mkdir
+from os.path import exists
+import sys
+
+import docker
+from tqdm import tqdm
+from neo4j import GraphDatabase
+from neo4j.exceptions import ServiceUnavailable, CypherSyntaxError
+
+parent_dir = str(Path(__file__).resolve().parent.parent)
+sys.path.append(parent_dir)
+
+from src.neo4j_backup import Extractor, Importer
+from src.neo4j_backup._backends import from_json
+
+
+def test_core():
+
+    # Base clinet
+    client = docker.from_env()
+
+    # Kill all currently running containers
+    containers = client.containers.list()
+    for container in containers:
+        container.kill()
+
+    # Delete and remake dumps 
+    if exists(Path(__file__).parent / "dumps"):
+        rmtree(Path(__file__).parent / "dumps")
+    mkdir(Path(__file__).parent / "dumps")
+
+    # Load tags to pull
+    with open(Path(__file__).parent / "tags.json", "r") as f:
+        tags = set(load(f))
+
+    # Check what images have already been pulled from list
+    images = client.images.list()
+
+    # Loop through the images, and save tags
+    already_pulled_tags = set()
+    for image in images:
+        for tag in image.tags:
+            if tag.split(":")[1] in tags and tag.split(":")[0] == "neo4j":
+                already_pulled_tags.add(tag.split(":")[1])
+
+    # Pull tags to need to be pulled
+    tags_to_pull = tags - already_pulled_tags
+    for tag in tqdm(tags_to_pull, desc=f"Pulling Neo4j docker images"):
+        client.images.pull(f'neo4j:{tag}')
+
+    # Loop through the all tags, and run test
+    for tag in tags:
+
+        print("------------------------------------------------------------")
+        print(f"Running core data dump/import test on neo4j:{tag}")
+        print("------------------------------------------------------------")
+
+        # Run container
+        container = client.containers.run(f'neo4j:{tag}', 
+                                        detach=True, 
+                                        ports={'7474/tcp': 7474, '7687/tcp': 7687},
+                                        environment={'NEO4J_AUTH': 'neo4j/password'}
+                                        )
+        
+        # Database driver
+        uri = "neo4j://localhost:7687"
+        username = "neo4j"
+        password = "password"
+        driver = GraphDatabase.driver(uri, auth=(username, password), encrypted=False)
+
+        # Load queries
+        with open(Path(__file__).parent / "queries/movies.cypher", "r") as f:
+            movies_query = f.read()
+        with open(Path(__file__).parent / "queries/modify_node.cypher", "r") as f:
+            modifiy_node = f.read()
+        with open(Path(__file__).parent / "queries/modify_rel.cypher", "r") as f:
+            modifiy_rel = f.read()
+        with open(Path(__file__).parent / "queries/lonely_node.cypher", "r") as f:
+            lonely_node = f.read()
+        with open(Path(__file__).parent / "queries/id_as_prop.cypher", "r") as f:
+            id_as_prop = f.read()
+        with open(Path(__file__).parent / "queries/v5_constraint.cypher", "r") as f:
+            v5_contraint = f.read()
+        with open(Path(__file__).parent / "queries/v4_constraint.cypher", "r") as f:
+            v4_contraint = f.read()
+
+        # Create a graph with known input data, extract data
+        while True:
+            print(f"Attempting to connect to orginial neo4j:{tag}")
+            try:
+
+                with driver.session(database="neo4j") as session:
+
+                    # Load in inital data
+                    session.run(movies_query)
+                    session.run(modifiy_node)
+                    session.run(modifiy_rel)
+                    session.run(lonely_node)
+                    session.run(id_as_prop)
+
+                    try:
+                        session.run(v5_contraint)
+                    except CypherSyntaxError:
+                        session.run(v4_contraint)
+                    
+                    # Extract out data in Neo4j
+                    extractor = Extractor(project_dir=Path(__file__).parent / f"dumps/main_{tag}", driver=driver, database="neo4j",
+                                          input_yes=True, compress=True, indent_size=0, json_file_size=int("0xFF", 16), pull_uniqueness_constraints=True)
+                    extractor.extract_data()
+
+                break
+            except ServiceUnavailable:
+                sleep(5)
+
+        # Destory previous graph
+        container.kill()
+        container = client.containers.run(f'neo4j:{tag}', 
+                                detach=True, 
+                                ports={'7474/tcp': 7474, '7687/tcp': 7687},
+                                environment={'NEO4J_AUTH': 'neo4j/password'}
+                                )
+        driver = GraphDatabase.driver(uri, auth=(username, password), encrypted=False)
+
+        # Input extracted data into new graph, extract data again
+        while True:
+            print(f"Attempting to connect to duplicate neo4j:{tag}")
+            try:
+                with driver.session(database="neo4j") as session:
+
+                    # Import extracted data back into the empty database
+                    importer = Importer(project_dir=Path(__file__).parent / f"dumps/main_{tag}", driver=driver, database="neo4j", 
+                                        input_yes=True)
+                    importer.import_data()
+
+                    # Extract out imported data
+                    extractor = Extractor(project_dir=Path(__file__).parent / f"dumps/duplicate_{tag}", driver=driver, database="neo4j",
+                                          input_yes=True, compress=True, indent_size=0, json_file_size=int("0xFF", 16), pull_uniqueness_constraints=True)
+                    extractor.extract_data()
+
+                break
+            except ServiceUnavailable:
+                sleep(5)
+
+        # Kill container again
+        container.kill()
+
+
+def _reindex(nodes, rels):
+    node_dict = dict()
+    for node in nodes:
+        current_node_id = node["node_id"]
+        true_node_id = node["node_props"]["node_id"]
+        node_dict[current_node_id] = true_node_id
+
+    new_nodes = []
+    for node in nodes:
+        node["node_id"] = node_dict[node["node_id"]]
+        node["node_props"].pop("node_id")
+        new_nodes.append(node)
+
+    new_rels = list()
+    for rel in rels:
+        rel["rel_id"] = rel["rel_props"]["rel_id"]
+        rel["rel_props"].pop("rel_id")
+        rel["start_node_id"] = node_dict[rel["start_node_id"]]
+        rel["end_node_id"] = node_dict[rel["end_node_id"]]
+        new_rels.append(rel)
+
+    return new_nodes, new_rels
+
+def _pull_dicts(dump):
+    nodes = []
+    rels = []
+    for file in dump.iterdir():
+        if "node" in file.name:
+            nodes.extend(from_json(file, compressed=True))
+        elif "rel" in file.name:
+            rels.extend(from_json(file, compressed=True))
+    nodes, rels = _reindex(nodes, rels)
+    return nodes, rels
+
+
+def _test_equiv(list1, list2):
+    # Verify that list1 is equal to list2, even if the items are unsorted
+    assert len(list1) == len(list2)
+    sorted_list1 = sorted(list1, key=lambda d: str(sorted(d.items())))
+    sorted_list2 = sorted(list2, key=lambda d: str(sorted(d.items())))
+    for dict1, dict2 in zip(sorted_list1, sorted_list2):
+        assert dict1 == dict2
+
+
+def test_equvilant_nodes():
+
+    # Load tags
+    with open(Path(__file__).parent / "tags.json", "r") as f:
+        tags = set(load(f))
+
+    for tag in tags:
+        main_dir = Path(__file__).parent / f"dumps/main_{tag}/data"
+        main_nodes, main_rels = _pull_dicts(main_dir)
+        
+        dup_dir = Path(__file__).parent / f"dumps/duplicate_{tag}/data"
+        dup_nodes, dup_rels = _pull_dicts(dup_dir)
+
+        _test_equiv(main_nodes, dup_nodes)
+
+
+def test_equvilant_rels():
+
+    # Load tags
+    with open(Path(__file__).parent / "tags.json", "r") as f:
+        tags = set(load(f))
+
+    for tag in tags:
+        main_dir = Path(__file__).parent / f"dumps/main_{tag}/data"
+        main_nodes, main_rels = _pull_dicts(main_dir)
+        
+        dup_dir = Path(__file__).parent / f"dumps/duplicate_{tag}/data"
+        dup_nodes, dup_rels = _pull_dicts(dup_dir)
+
+        _test_equiv(main_rels, dup_rels)
+
+
+def test_equvilant_meta():
+
+    with open(Path(__file__).parent / "tags.json", "r") as f:
+        tags = set(load(f)) 
+
+    ignore = ["unique_prop_key.json", "db_id.json", "compressed.json"]
+
+    for tag in tags:
+        main_dir = Path(__file__).parent / f"dumps/main_{tag}"
+        dup_dir = Path(__file__).parent / f"dumps/duplicate_{tag}"
+
+        for file in main_dir.iterdir():
+            if file.is_file() and file.name not in ignore:
+                with open(file, "r") as f:
+                    data1 = load(f)
+                with open(dup_dir / file.name) as f:
+                    data2 = load(f)
+
+                if not data1:
+                    assert data1 == data2
+                elif isinstance(data1, list):
+                    if isinstance(data1[0], dict):
+                        sorted_list1 = sorted(data1, key=lambda d: str(sorted(d.items())))
+                        sorted_list2 = sorted(data2, key=lambda d: str(sorted(d.items())))
+                        for dict1, dict2 in zip(sorted_list1, sorted_list2):
+                            assert dict1 == dict2
+                    else:
+                        sorted_list1 = sorted(data1)
+                        sorted_list2 = sorted(data2)
+                        assert sorted_list1 == sorted_list2
+                else:
+                    assert data1 == data2 
+
+
+if __name__ == "__main__":
+
+    test_core()
+    test_equvilant_nodes()
+    test_equvilant_rels()
+    test_equvilant_meta()


### PR DESCRIPTION
Major changes

- Added tests to verify code is working multiple neo4j versions. For now, this is run locally. Will become integrated unit tests in the future.

Minor changes

- Bug fix, let all strings like object default to string. Only modify temporal/point values as clean up after UNWIND statements in import
- Store temporal/point values as ["$point(", "$date(", "$time(", "$datetime(", "$duration("]
- Store all strings as just strings 
- Drop support for neo4j <= 4.2